### PR TITLE
Add package goconconstraint for requiring minimum Go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: go
+go:
+- 1.1.2
+- 1.2.2
+- 1.3.3
+- 1.4.3
+- 1.5.4
+- 1.6.4
+- 1.7.6
+- 1.8.3
+- 1.9
+sudo: false
+notifications:
+  email:
+    on_success: never
+    on_failure: always
+install: true
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+test:
+	go run scripts/test_runner.go
+
+.PHONY: test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# goconstruct
+
+ Package goconstraint is a lightweight way for you to declare that your code
+ requires a minimum Go runtime version, using a blank import.
+
+## License
+
+This package is licensed under the `MIT License`. Please see
+the [LICENSE](https://github.com/theckman/goconstraint/blob/master/LICENSE) file
+for more details.
+
+## Usage
+
+ Say you wanted to require that your code only build with Go 1.9+, you would
+ include the following at the top of the file that has the runtime dependency
+ on the specific version:
+
+```Go
+import _ "github.com/theckman/goconstraint/go1.9/gte"
+```
+
+ All go versions, that can be restricted by build tag, have been supported (Go
+ 1.1+). There's also a package to import to always force the latest minor
+ version of the runtime:
+
+```Go
+import _ "github.com/theckman/goconstraint/latest"
+```
+
+ While this may be enticing to use, please remember that if you do use it a new
+ Go release may break your software's ability to build. Using the
+ version-specific constraints is recommended.
+
+ It's also recommended that you include a comment with the import, to indicate
+ which functionality/feature is required from that Go version (while also
+ including a Golang issue link if possible).
+
+ If you try to build a project against a runtime that's too old, you'll see a
+ build failure similar to this with the version number changing based on the
+ requirement:
+
+```Go
+goconstraint/go1.9/gte/constraint.go:10: undefined: __SOFTWARE_REQUIRES_GO_VERSION_1_9__
+```

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// Package goconstraint is a lightweight way for you to declare that your code
+// requires a minimum Go runtime version, using a blank import.
+//
+// Say you wanted to require that your code only build with Go 1.9+, you would
+// include the following at the top of the file that has the runtime dependency
+// on the specific version:
+//
+//		import _ "github.com/theckman/goconstraint/go1.9/gte"
+//
+// All go versions, that can be restricted by build tag, have been supported (Go
+// 1.1+). There's also a package to import to always force the latest minor
+// version of the runtime:
+//
+//		import _ "github.com/theckman/goconstraint/latest"
+//
+// While this may be enticing to use, please remember that if you do use it a
+// new Go release may break your software's ability to build. Using the
+// version-specific constraints is recommended.
+//
+// It's also recommended that you include a comment with the import, to indicate
+// which functionality/feature is required from that Go version (while also
+// including a Golang issue link if possible).
+//
+// If you try to build a project against a runtime that's too old, you'll see a
+// build failure similar to this with the version number changing based on the
+// requirement:
+//
+//		goconstraint/go1.9/gte/constraint.go:10: undefined: __SOFTWARE_REQUIRES_GO_VERSION_1_9__
+//
+package goconstraint

--- a/go1.1/gte/constraint.go
+++ b/go1.1/gte/constraint.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// Package gtego11 should only be used as a blank import. If imported, it
+// will only compile if the Go runtime version is >= 1.1.
+package gtego11
+
+// This will fail to compile if the Go runtime version isn't >= 1.1.
+var _ = __SOFTWARE_REQUIRES_GO_VERSION_1_1__

--- a/go1.1/gte/go11.go
+++ b/go1.1/gte/go11.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// +build go1.1
+
+package gtego11
+
+const __SOFTWARE_REQUIRES_GO_VERSION_1_1__ = uint8(0)

--- a/go1.1/gte/go11_test.go
+++ b/go1.1/gte/go11_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+package gtego11_test
+
+import (
+	"testing"
+
+	_ "github.com/theckman/goconstraint/go1.1/gte"
+)
+
+// This test is is intentionally blank and exists only so `go test` believes
+// there is something to test.
+//
+// The blank import above is actually what invokes the test of this package. If
+// the import succeeds (the code compiles), the test passed.
+func Test(t *testing.T) {}

--- a/go1.2/gte/constraint.go
+++ b/go1.2/gte/constraint.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// Package gtego12 should only be used as a blank import. If imported, it
+// will only compile if the Go runtime version is >= 1.2.
+package gtego12
+
+// This will fail to compile if the Go runtime version isn't >= 1.2.
+var _ = __SOFTWARE_REQUIRES_GO_VERSION_1_2__

--- a/go1.2/gte/go12.go
+++ b/go1.2/gte/go12.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// +build go1.2
+
+package gtego12
+
+const __SOFTWARE_REQUIRES_GO_VERSION_1_2__ = uint8(0)

--- a/go1.2/gte/go12_test.go
+++ b/go1.2/gte/go12_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+package gtego12_test
+
+import (
+	"testing"
+
+	_ "github.com/theckman/goconstraint/go1.2/gte"
+)
+
+// This test is is intentionally blank and exists only so `go test` believes
+// there is something to test.
+//
+// The blank import above is actually what invokes the test of this package. If
+// the import succeeds (the code compiles), the test passed.
+func Test(t *testing.T) {}

--- a/go1.3/gte/constraint.go
+++ b/go1.3/gte/constraint.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// Package gtego13 should only be used as a blank import. If imported, it
+// will only compile if the Go runtime version is >= 1.3.
+package gtego13
+
+// This will fail to compile if the Go runtime version isn't >= 1.3.
+var _ = __SOFTWARE_REQUIRES_GO_VERSION_1_3__

--- a/go1.3/gte/go13.go
+++ b/go1.3/gte/go13.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// +build go1.3
+
+package gtego13
+
+const __SOFTWARE_REQUIRES_GO_VERSION_1_3__ = uint8(0)

--- a/go1.3/gte/go13_test.go
+++ b/go1.3/gte/go13_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+package gtego13_test
+
+import (
+	"testing"
+
+	_ "github.com/theckman/goconstraint/go1.3/gte"
+)
+
+// This test is is intentionally blank and exists only so `go test` believes
+// there is something to test.
+//
+// The blank import above is actually what invokes the test of this package. If
+// the import succeeds (the code compiles), the test passed.
+func Test(t *testing.T) {}

--- a/go1.4/gte/constraint.go
+++ b/go1.4/gte/constraint.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// Package gtego14 should only be used as a blank import. If imported, it
+// will only compile if the Go runtime version is >= 1.4.
+package gtego14
+
+// This will fail to compile if the Go runtime version isn't >= 1.4.
+var _ = __SOFTWARE_REQUIRES_GO_VERSION_1_4__

--- a/go1.4/gte/go14.go
+++ b/go1.4/gte/go14.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// +build go1.4
+
+package gtego14
+
+const __SOFTWARE_REQUIRES_GO_VERSION_1_4__ = uint8(0)

--- a/go1.4/gte/go14_test.go
+++ b/go1.4/gte/go14_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+package gtego14_test
+
+import (
+	"testing"
+
+	_ "github.com/theckman/goconstraint/go1.4/gte"
+)
+
+// This test is is intentionally blank and exists only so `go test` believes
+// there is something to test.
+//
+// The blank import above is actually what invokes the test of this package. If
+// the import succeeds (the code compiles), the test passed.
+func Test(t *testing.T) {}

--- a/go1.5/gte/constraint.go
+++ b/go1.5/gte/constraint.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// Package gtego15 should only be used as a blank import. If imported, it
+// will only compile if the Go runtime version is >= 1.5.
+package gtego15
+
+// This will fail to compile if the Go runtime version isn't >= 1.5.
+var _ = __SOFTWARE_REQUIRES_GO_VERSION_1_5__

--- a/go1.5/gte/go15.go
+++ b/go1.5/gte/go15.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// +build go1.5
+
+package gtego15
+
+const __SOFTWARE_REQUIRES_GO_VERSION_1_5__ = uint8(0)

--- a/go1.5/gte/go15_test.go
+++ b/go1.5/gte/go15_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+package gtego15_test
+
+import (
+	"testing"
+
+	_ "github.com/theckman/goconstraint/go1.5/gte"
+)
+
+// This test is is intentionally blank and exists only so `go test` believes
+// there is something to test.
+//
+// The blank import above is actually what invokes the test of this package. If
+// the import succeeds (the code compiles), the test passed.
+func Test(t *testing.T) {}

--- a/go1.6/gte/constraint.go
+++ b/go1.6/gte/constraint.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// Package gtego16 should only be used as a blank import. If imported, it
+// will only compile if the Go runtime version is >= 1.6.
+package gtego16
+
+// This will fail to compile if the Go runtime version isn't >= 1.6.
+var _ = __SOFTWARE_REQUIRES_GO_VERSION_1_6__

--- a/go1.6/gte/go16.go
+++ b/go1.6/gte/go16.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// +build go1.6
+
+package gtego16
+
+const __SOFTWARE_REQUIRES_GO_VERSION_1_6__ = uint8(0)

--- a/go1.6/gte/go16_test.go
+++ b/go1.6/gte/go16_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+package gtego16_test
+
+import (
+	"testing"
+
+	_ "github.com/theckman/goconstraint/go1.6/gte"
+)
+
+// This test is is intentionally blank and exists only so `go test` believes
+// there is something to test.
+//
+// The blank import above is actually what invokes the test of this package. If
+// the import succeeds (the code compiles), the test passed.
+func Test(t *testing.T) {}

--- a/go1.7/gte/constraint.go
+++ b/go1.7/gte/constraint.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// Package gtego17 should only be used as a blank import. If imported, it
+// will only compile if the Go runtime version is >= 1.7.
+package gtego17
+
+// This will fail to compile if the Go runtime version isn't >= 1.7.
+var _ = __SOFTWARE_REQUIRES_GO_VERSION_1_7__

--- a/go1.7/gte/go17.go
+++ b/go1.7/gte/go17.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// +build go1.7
+
+package gtego17
+
+const __SOFTWARE_REQUIRES_GO_VERSION_1_7__ = uint8(0)

--- a/go1.7/gte/go17_test.go
+++ b/go1.7/gte/go17_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+package gtego17_test
+
+import (
+	"testing"
+
+	_ "github.com/theckman/goconstraint/go1.7/gte"
+)
+
+// This test is is intentionally blank and exists only so `go test` believes
+// there is something to test.
+//
+// The blank import above is actually what invokes the test of this package. If
+// the import succeeds (the code compiles), the test passed.
+func Test(t *testing.T) {}

--- a/go1.8/gte/constraint.go
+++ b/go1.8/gte/constraint.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// Package gtego18 should only be used as a blank import. If imported, it
+// will only compile if the Go runtime version is >= 1.8.
+package gtego18
+
+// This will fail to compile if the Go runtime version isn't >= 1.8.
+var _ = __SOFTWARE_REQUIRES_GO_VERSION_1_8__

--- a/go1.8/gte/go18.go
+++ b/go1.8/gte/go18.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// +build go1.8
+
+package gtego18
+
+const __SOFTWARE_REQUIRES_GO_VERSION_1_8__ = uint8(0)

--- a/go1.8/gte/go18_test.go
+++ b/go1.8/gte/go18_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+package gtego18_test
+
+import (
+	"testing"
+
+	_ "github.com/theckman/goconstraint/go1.8/gte"
+)
+
+// This test is is intentionally blank and exists only so `go test` believes
+// there is something to test.
+//
+// The blank import above is actually what invokes the test of this package. If
+// the import succeeds (the code compiles), the test passed.
+func Test(t *testing.T) {}

--- a/go1.9/gte/constraint.go
+++ b/go1.9/gte/constraint.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// Package gtego19 should only be used as a blank import. If imported, it
+// will only compile if the Go runtime version is >= 1.9.
+package gtego19
+
+// This will fail to compile if the Go runtime version isn't >= 1.9.
+var _ = __SOFTWARE_REQUIRES_GO_VERSION_1_9__

--- a/go1.9/gte/go19.go
+++ b/go1.9/gte/go19.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// +build go1.9
+
+package gtego19
+
+const __SOFTWARE_REQUIRES_GO_VERSION_1_9__ = uint8(0)

--- a/go1.9/gte/go19_test.go
+++ b/go1.9/gte/go19_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+package gtego19_test
+
+import (
+	"testing"
+
+	_ "github.com/theckman/goconstraint/go1.9/gte"
+)
+
+// This test is is intentionally blank and exists only so `go test` believes
+// there is something to test.
+//
+// The blank import above is actually what invokes the test of this package. If
+// the import succeeds (the code compiles), the test passed.
+func Test(t *testing.T) {}

--- a/latest/constraint.go
+++ b/latest/constraint.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+// Package latestgo should only be used as a blank import. If imported, it
+// will only compile if the Go runtime version is == the latest version.
+//
+// Instead of using this package, you should use one of the versioned
+// constraints. Otherwise your code may suddenly fail to build.
+package latestgo
+
+import _ "github.com/theckman/goconstraint/go1.9/gte"

--- a/latest/constraint_test.go
+++ b/latest/constraint_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+package latestgo_test
+
+import (
+	"testing"
+
+	_ "github.com/theckman/goconstraint/latest"
+)
+
+// This test is is intentionally blank and exists only so `go test` believes
+// there is something to test.
+//
+// The blank import above is actually what invokes the test of this package. If
+// the import succeeds (the code compiles), the test passed.
+func Test(t *testing.T) {}

--- a/scripts/test_runner.go
+++ b/scripts/test_runner.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2017 Tim Heckman
+// Use of this source code is governed by the MIT License that can be found in
+// the LICENSE file at the root of this repository.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strconv"
+)
+
+const (
+	maxMajor = uint64(1)
+
+	minMinor = uint64(1)
+	maxMinor = uint64(9)
+)
+
+var versionsToCheck = []string{
+	"go1.1", "go1.2", "go1.3", "go1.4",
+	"go1.5", "go1.6", "go1.7", "go1.8",
+	"go1.9",
+}
+
+var verRegexp = regexp.MustCompile(`go(\d+)\.(\d+)(?:\.(\d+))?`)
+
+func main() {
+	toTest, toFail, err := versionsToTest()
+
+	if err != nil {
+		log.Fatalf("failed to get versions to test: %s", err)
+	}
+
+	for _, test := range toTest {
+		if err := runTest(test, false); err != nil {
+			log.Fatalf("last test suite (%q) unexpectedly failed: %s", test, err)
+		}
+	}
+
+	for _, test := range toFail {
+		if err := runTest(test, true); err != nil {
+			log.Fatalf("last test suite (%q) unexpectedly failed: %s", test, err)
+		}
+	}
+}
+
+func versionsToTest() (pass []string, fail []string, err error) {
+	major, minor, _, err := parseVersion(runtime.Version())
+
+	if err != nil {
+		log.Fatalf("failed to getVersion(): %s", err)
+	}
+
+	if err := validateVersions(major, minor); err != nil {
+		log.Fatal(err)
+	}
+
+	var toTest []string
+	var toFail []string
+
+	for _, ver := range versionsToCheck {
+		verMajor, verMinor, _, err := parseVersion(ver)
+
+		if err != nil {
+			return nil, nil, fmt.Errorf("unexpected parse error for %q: %s", ver, err)
+		}
+
+		if verMajor != major {
+			toFail = append(toFail, ver)
+		} else {
+			if verMinor <= minor {
+				toTest = append(toTest, ver)
+			} else {
+				toFail = append(toFail, ver)
+			}
+		}
+	}
+
+	return toTest, toFail, nil
+}
+
+func parseVersion(version string) (major, minor, patch uint64, err error) {
+	match := verRegexp.FindAllStringSubmatch(version, -1)
+
+	if len(match) < 1 {
+		return 0, 0, 0, fmt.Errorf("unknown runtime version: %s", version)
+	}
+
+	if major, err = strconv.ParseUint(match[0][1], 10, 64); err != nil {
+		return
+	}
+
+	if minor, err = strconv.ParseUint(match[0][2], 10, 64); err != nil {
+		return
+	}
+
+	if match[0][3] != "" {
+		if patch, err = strconv.ParseUint(match[0][3], 10, 64); err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func validateVersions(major, minor uint64) error {
+	if major != maxMajor {
+		return fmt.Errorf("unknown Go major version: %d", major)
+	}
+
+	if minor < minMinor || minor > maxMinor {
+		return fmt.Errorf("unknown Go minor version: %d; valid range %d - %d", minor, minMinor, maxMinor)
+	}
+
+	return nil
+}
+
+func runTest(test string, shouldFail bool) error {
+	dir := fmt.Sprintf("./%s/...", test)
+
+	fmt.Printf("go test -v %s # should fail: %t\n", dir, shouldFail)
+
+	cmd := exec.Command("go", "test", "-v", dir)
+
+	if !shouldFail {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stdout
+	}
+
+	err := cmd.Run()
+
+	if shouldFail {
+		if err != nil {
+			fmt.Printf("(%q test failed as expected; continuing)\n", test)
+			return nil
+		}
+		log.Fatalf("expected %q to fail", test)
+	}
+
+	return err
+}


### PR DESCRIPTION
This adds package `goconstraint` which gives you a way to indicate what your
minimum Golang runtime version is simply by using a blank import. This also
includes a `latest` path that can be used to always force the latest minor
revision of the Go runtime.

Signed-off-by: Tim Heckman <t@heckman.io>