### PR TITLE
Update 1.8 and 1.9 tests to use the latest patch releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ go:
 - 1.5.4
 - 1.6.4
 - 1.7.6
-- 1.8.3
-- 1.9
+- 1.8.5
+- 1.9.2
 sudo: false
 notifications:
   email:


### PR DESCRIPTION
- 1.8.5
- 1.9.2

Signed-off-by: Tim Heckman <t@heckman.io>