### PR TITLE
Update copyright of the test_runner Go program

### DIFF
--- a/scripts/test_runner.go
+++ b/scripts/test_runner.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Tim Heckman
+// Copyright (c) 2017-2018 Tim Heckman
 // Use of this source code is governed by the MIT License that can be found in
 // the LICENSE file at the root of this repository.
 


### PR DESCRIPTION
As it's released under the MIT license and I've made changes in 2018.

Signed-off-by: Tim Heckman <t@heckman.io>